### PR TITLE
feat: Add Hero Auction Decoders for DFK

### DIFF
--- a/services/decoder/protocols/defi-kingdoms/abis/defi-kingdoms.hero-auction.abi.json
+++ b/services/decoder/protocols/defi-kingdoms/abis/defi-kingdoms.hero-auction.abi.json
@@ -1,0 +1,1082 @@
+[
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "auctionId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        }
+      ],
+      "name": "AuctionCancelled",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "auctionId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "owner",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "startingPrice",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "endingPrice",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "duration",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "winner",
+          "type": "address"
+        }
+      ],
+      "name": "AuctionCreated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "auctionId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "totalPrice",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "winner",
+          "type": "address"
+        }
+      ],
+      "name": "AuctionSuccessful",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "feeAddress",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "feePercent",
+          "type": "uint256"
+        }
+      ],
+      "name": "FeeAddressAdded",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "source",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint64",
+          "name": "timestamp",
+          "type": "uint64"
+        }
+      ],
+      "name": "FeeDisbursed",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint8",
+          "name": "version",
+          "type": "uint8"
+        }
+      ],
+      "name": "Initialized",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "Paused",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "previousAdminRole",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "newAdminRole",
+          "type": "bytes32"
+        }
+      ],
+      "name": "RoleAdminChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "RoleGranted",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "RoleRevoked",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "Unpaused",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "BIDDER_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "DEFAULT_ADMIN_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "ERC721",
+      "outputs": [
+        {
+          "internalType": "contract IERC721Upgradeable",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "MODERATOR_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "assistingAuction",
+      "outputs": [
+        {
+          "internalType": "contract IAssistingAuctionUpgradeable",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "auctionIdOffset",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "auctions",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "seller",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint128",
+          "name": "startingPrice",
+          "type": "uint128"
+        },
+        {
+          "internalType": "uint128",
+          "name": "endingPrice",
+          "type": "uint128"
+        },
+        {
+          "internalType": "uint64",
+          "name": "duration",
+          "type": "uint64"
+        },
+        {
+          "internalType": "uint64",
+          "name": "startedAt",
+          "type": "uint64"
+        },
+        {
+          "internalType": "address",
+          "name": "winner",
+          "type": "address"
+        },
+        {
+          "internalType": "bool",
+          "name": "open",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_tokenId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_bidAmount",
+          "type": "uint256"
+        }
+      ],
+      "name": "bid",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_bidder",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_tokenId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_bidAmount",
+          "type": "uint256"
+        }
+      ],
+      "name": "bidFor",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_tokenId",
+          "type": "uint256"
+        }
+      ],
+      "name": "cancelAuction",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_tokenId",
+          "type": "uint256"
+        }
+      ],
+      "name": "cancelAuctionWhenPaused",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_tokenId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint128",
+          "name": "_startingPrice",
+          "type": "uint128"
+        },
+        {
+          "internalType": "uint128",
+          "name": "_endingPrice",
+          "type": "uint128"
+        },
+        {
+          "internalType": "uint64",
+          "name": "_duration",
+          "type": "uint64"
+        },
+        {
+          "internalType": "address",
+          "name": "_winner",
+          "type": "address"
+        }
+      ],
+      "name": "createAuction",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "feeAddresses",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "feePercents",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_tokenId",
+          "type": "uint256"
+        }
+      ],
+      "name": "getAuction",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "address",
+              "name": "seller",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "tokenId",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint128",
+              "name": "startingPrice",
+              "type": "uint128"
+            },
+            {
+              "internalType": "uint128",
+              "name": "endingPrice",
+              "type": "uint128"
+            },
+            {
+              "internalType": "uint64",
+              "name": "duration",
+              "type": "uint64"
+            },
+            {
+              "internalType": "uint64",
+              "name": "startedAt",
+              "type": "uint64"
+            },
+            {
+              "internalType": "address",
+              "name": "winner",
+              "type": "address"
+            },
+            {
+              "internalType": "bool",
+              "name": "open",
+              "type": "bool"
+            }
+          ],
+          "internalType": "struct Auction",
+          "name": "",
+          "type": "tuple"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "_tokenIds",
+          "type": "uint256[]"
+        }
+      ],
+      "name": "getAuctions",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "address",
+              "name": "seller",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "tokenId",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint128",
+              "name": "startingPrice",
+              "type": "uint128"
+            },
+            {
+              "internalType": "uint128",
+              "name": "endingPrice",
+              "type": "uint128"
+            },
+            {
+              "internalType": "uint64",
+              "name": "duration",
+              "type": "uint64"
+            },
+            {
+              "internalType": "uint64",
+              "name": "startedAt",
+              "type": "uint64"
+            },
+            {
+              "internalType": "address",
+              "name": "winner",
+              "type": "address"
+            },
+            {
+              "internalType": "bool",
+              "name": "open",
+              "type": "bool"
+            }
+          ],
+          "internalType": "struct Auction[]",
+          "name": "",
+          "type": "tuple[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_tokenId",
+          "type": "uint256"
+        }
+      ],
+      "name": "getCurrentPrice",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        }
+      ],
+      "name": "getRoleAdmin",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_address",
+          "type": "address"
+        }
+      ],
+      "name": "getUserAuctions",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "grantRole",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "hasRole",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_heroCoreAddress",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "_crystalAddress",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_cut",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "_assistingAuctionAddress",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_auctionIdOffset",
+          "type": "uint256"
+        }
+      ],
+      "name": "initialize",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_tokenId",
+          "type": "uint256"
+        }
+      ],
+      "name": "isOnAuction",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bytes",
+          "name": "",
+          "type": "bytes"
+        }
+      ],
+      "name": "onERC721Received",
+      "outputs": [
+        {
+          "internalType": "bytes4",
+          "name": "",
+          "type": "bytes4"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "ownerCut",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "pause",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "paused",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "powerToken",
+      "outputs": [
+        {
+          "internalType": "contract IPowerToken",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "powerUpManager",
+      "outputs": [
+        {
+          "internalType": "contract IPowerUpManagerUpgradeable",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "renounceRole",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "revokeRole",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_auctionIdOffset",
+          "type": "uint256"
+        }
+      ],
+      "name": "setAuctionIDOffset",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_newERC721Address",
+          "type": "address"
+        }
+      ],
+      "name": "setERC721",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address[]",
+          "name": "_feeAddresses",
+          "type": "address[]"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "_feePercents",
+          "type": "uint256[]"
+        }
+      ],
+      "name": "setFees",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_powerTokenAddress",
+          "type": "address"
+        }
+      ],
+      "name": "setPowerToken",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_powerUpManager",
+          "type": "address"
+        }
+      ],
+      "name": "setPowerUpManager",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes4",
+          "name": "interfaceId",
+          "type": "bytes4"
+        }
+      ],
+      "name": "supportsInterface",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "totalAuctions",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "unpause",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "userAuctions",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ]

--- a/services/decoder/protocols/defi-kingdoms/defi-kingdoms.configs.ts
+++ b/services/decoder/protocols/defi-kingdoms/defi-kingdoms.configs.ts
@@ -7,6 +7,12 @@ const configs: Configs = [
         protocol_name: "defi-kingdoms",
         chain_name: "defi-kingdoms-mainnet",
     },
+    {
+        address: "0xc390faa4c7f66e4d62e59c231d5bed32ff77bef0",
+        is_factory: false,
+        protocol_name: "defi-kingdoms",
+        chain_name: "defi-kingdoms-mainnet",
+    },
 ];
 
 export default configs;

--- a/services/decoder/protocols/defi-kingdoms/defi-kingdoms.decoders.ts
+++ b/services/decoder/protocols/defi-kingdoms/defi-kingdoms.decoders.ts
@@ -7,6 +7,7 @@ import {
 } from "../../decoder.constants";
 import { decodeEventLog, type Abi } from "viem";
 import PetABI from "./abis/defi-kingdoms.pets.abi.json";
+import HERO_AUCTION_ABI from "./abis/defi-kingdoms.hero-auction.abi.json";
 import { TimestampParser } from "../../../../utils/functions";
 
 GoldRushDecoder.on(
@@ -61,6 +62,186 @@ GoldRushDecoder.on(
             action: DECODED_ACTION.TRANSFERRED,
             category: DECODED_EVENT_CATEGORY.GAMING,
             name: "Pet Fed",
+            protocol: {
+                logo: log_event.sender_logo_url as string,
+                name: "DeFi Kingdoms",
+            },
+            details,
+        };
+    }
+);
+
+GoldRushDecoder.on(
+    "defi-kingdoms:AuctionCreated",
+    ["defi-kingdoms-mainnet"],
+    HERO_AUCTION_ABI as Abi,
+    async (log_event, tx, chain_name, covalent_client): Promise<EventType> => {
+        const { raw_log_data, raw_log_topics } = log_event;
+
+        const { args: decoded } = decodeEventLog({
+            abi: HERO_AUCTION_ABI,
+            topics: raw_log_topics as [],
+            data: raw_log_data as `0x${string}`,
+            eventName: "AuctionCreated",
+        }) as {
+            eventName: "AuctionCreated";
+            args: {
+                auctionId: bigint;
+                owner: string;
+                tokenId: bigint;
+                startingPrice: bigint;
+                endingPrice: bigint;
+                duration: bigint;
+                winner: string;
+            };
+        };
+
+        const details: EventDetails = [
+            {
+                heading: "Auction ID",
+                value: decoded.auctionId.toString(),
+                type: "text",
+            },
+            {
+                heading: "Owner",
+                value: decoded.owner.toString(),
+                type: "address",
+            },
+            {
+                heading: "Token ID",
+                value: decoded.tokenId.toString(),
+                type: "text",
+            },
+            {
+                heading: "Starting Price",
+                value: decoded.startingPrice.toString(),
+                type: "text",
+            },
+            {
+                heading: "Ending Price",
+                value: decoded.endingPrice.toString(),
+                type: "text",
+            },
+            {
+                heading: "Duration",
+                value: decoded.duration.toString(),
+                type: "text",
+            },
+            {
+                heading: "Winner",
+                value: decoded.winner.toString(),
+                type: "address",
+            },
+        ];
+
+        return {
+            action: DECODED_ACTION.TRANSFERRED,
+            category: DECODED_EVENT_CATEGORY.GAMING,
+            name: "Auction Created",
+            protocol: {
+                logo: log_event.sender_logo_url as string,
+                name: "DeFi Kingdoms",
+            },
+            details,
+        };
+    }
+);
+
+GoldRushDecoder.on(
+    "defi-kingdoms:AuctionCancelled",
+    ["defi-kingdoms-mainnet"],
+    HERO_AUCTION_ABI as Abi,
+    async (log_event, tx, chain_name, covalent_client): Promise<EventType> => {
+        const { raw_log_data, raw_log_topics } = log_event;
+
+        const { args: decoded } = decodeEventLog({
+            abi: HERO_AUCTION_ABI,
+            topics: raw_log_topics as [],
+            data: raw_log_data as `0x${string}`,
+            eventName: "AuctionCancelled",
+        }) as {
+            eventName: "AuctionCancelled";
+            args: {
+                auctionId: bigint;
+                tokenId: bigint;
+            };
+        };
+
+        const details: EventDetails = [
+            {
+                heading: "Auction ID",
+                value: decoded.auctionId.toString(),
+                type: "text",
+            },
+            {
+                heading: "Token ID",
+                value: decoded.tokenId.toString(),
+                type: "text",
+            },
+        ];
+
+        return {
+            action: DECODED_ACTION.TRANSFERRED,
+            category: DECODED_EVENT_CATEGORY.GAMING,
+            name: "Auction Cancelled",
+            protocol: {
+                logo: log_event.sender_logo_url as string,
+                name: "DeFi Kingdoms",
+            },
+            details,
+        };
+    }
+);
+
+GoldRushDecoder.on(
+    "defi-kingdoms:AuctionSuccessful",
+    ["defi-kingdoms-mainnet"],
+    HERO_AUCTION_ABI as Abi,
+    async (log_event, tx, chain_name, covalent_client): Promise<EventType> => {
+        const { raw_log_data, raw_log_topics } = log_event;
+
+        const { args: decoded } = decodeEventLog({
+            abi: HERO_AUCTION_ABI,
+            topics: raw_log_topics as [],
+            data: raw_log_data as `0x${string}`,
+            eventName: "AuctionSuccessful",
+        }) as {
+            eventName: "AuctionSuccessful";
+            args: {
+                auctionId: bigint;
+                tokenId: bigint;
+                totalPrice: bigint;
+                winner: string;
+            };
+        };
+
+        const details: EventDetails = [
+            {
+                heading: "Auction ID",
+                value: decoded.auctionId.toString(),
+                type: "text",
+            },
+            {
+                heading: "Token ID",
+                value: decoded.tokenId.toString(),
+                type: "text",
+            },
+            {
+                heading: "Total Price",
+                value: decoded.totalPrice.toString(),
+                type: "text",
+            },
+            {
+                heading: "Winner",
+                value: decoded.winner.toString(),
+                type: "address",
+            },
+        ];
+
+        return {
+            action: DECODED_ACTION.TRANSFERRED,
+            category: DECODED_EVENT_CATEGORY.GAMING,
+            name: "Auction Successful",
             protocol: {
                 logo: log_event.sender_logo_url as string,
                 name: "DeFi Kingdoms",

--- a/services/decoder/protocols/defi-kingdoms/defi-kingdoms.decoders.ts
+++ b/services/decoder/protocols/defi-kingdoms/defi-kingdoms.decoders.ts
@@ -196,16 +196,6 @@ GoldRushDecoder.on(
                 type: "text",
             },
             {
-                heading: "Starting Price",
-                value: decoded.startingPrice.toString(),
-                type: "text",
-            },
-            {
-                heading: "Ending Price",
-                value: decoded.endingPrice.toString(),
-                type: "text",
-            },
-            {
                 heading: "Duration",
                 value: decoded.duration.toString(),
                 type: "text",
@@ -409,11 +399,6 @@ GoldRushDecoder.on(
             {
                 heading: "Token ID",
                 value: decoded.tokenId.toString(),
-                type: "text",
-            },
-            {
-                heading: "Total Price",
-                value: decoded.totalPrice.toString(),
                 type: "text",
             },
             {

--- a/services/decoder/protocols/defi-kingdoms/defi-kingdoms.decoders.ts
+++ b/services/decoder/protocols/defi-kingdoms/defi-kingdoms.decoders.ts
@@ -5,10 +5,10 @@ import {
     DECODED_ACTION,
     DECODED_EVENT_CATEGORY,
 } from "../../decoder.constants";
-import { decodeEventLog, type Abi } from "viem";
+import { decodeEventLog, type Abi, isAddress } from "viem";
 import PetABI from "./abis/defi-kingdoms.pets.abi.json";
 import HERO_AUCTION_ABI from "./abis/defi-kingdoms.hero-auction.abi.json";
-import { TimestampParser } from "../../../../utils/functions";
+import { TimestampParser, isNullAddress } from "../../../../utils/functions";
 import { prettifyCurrency } from "@covalenthq/client-sdk";
 
 GoldRushDecoder.on(
@@ -197,13 +197,17 @@ GoldRushDecoder.on(
             },
             {
                 heading: "Duration",
-                value: decoded.duration.toString(),
+                value: decoded.duration.toString() + " seconds",
                 type: "text",
             },
             {
                 heading: "Winner",
-                value: decoded.winner.toString(),
-                type: "address",
+                value: !isNullAddress(decoded.winner)
+                ? decoded.winner
+                : "No winner",
+                type: !isNullAddress(decoded.winner)
+                ? "address"
+                : "text",
             },
         ];
 
@@ -403,7 +407,9 @@ GoldRushDecoder.on(
             },
             {
                 heading: "Winner",
-                value: decoded.winner.toString(),
+                value: isNullAddress(decoded.winner)
+                    ? decoded.winner
+                    : "No winner",
                 type: "address",
             },
         ];

--- a/services/decoder/protocols/defi-kingdoms/defi-kingdoms.test.ts
+++ b/services/decoder/protocols/defi-kingdoms/defi-kingdoms.test.ts
@@ -19,4 +19,55 @@ describe("defi-kingdoms", () => {
         }
         expect(event?.details?.length).toEqual(4);
     });
+
+    test("defi-kingdoms-mainnet:Auction Created", async () => {
+        const res = await request(app)
+            .post("/api/v1/tx/decode")
+            .set({ "x-covalent-api-key": process.env.TEST_COVALENT_API_KEY })
+            .send({
+                chain_name: "defi-kingdoms-mainnet",
+                tx_hash:
+                    "0xa716c7e699fb26703b74c5cdae4a1d4930ef31353594185a9e7b40d881c56a57",
+            });
+        const { events } = res.body as { events: EventType[] };
+        const event = events.find(({ name }) => name === "Auction Created");
+        if (!event) {
+            throw Error("Event not found");
+        }
+        expect(event?.details?.length).toEqual(7);
+    });
+
+    test("defi-kingdoms-mainnet:Auction Cancelled", async () => {
+        const res = await request(app)
+            .post("/api/v1/tx/decode")
+            .set({ "x-covalent-api-key": process.env.TEST_COVALENT_API_KEY })
+            .send({
+                chain_name: "defi-kingdoms-mainnet",
+                tx_hash:
+                    "0x8a162e78fa5da11670555233052b31366c9784e78e18d849fe1edac06ad46c2c",
+            });
+        const { events } = res.body as { events: EventType[] };
+        const event = events.find(({ name }) => name === "Auction Cancelled");
+        if (!event) {
+            throw Error("Event not found");
+        }
+        expect(event?.details?.length).toEqual(2);
+    });
+
+    test("defi-kingdoms-mainnet:Auction Successful", async () => {
+        const res = await request(app)
+            .post("/api/v1/tx/decode")
+            .set({ "x-covalent-api-key": process.env.TEST_COVALENT_API_KEY })
+            .send({
+                chain_name: "defi-kingdoms-mainnet",
+                tx_hash:
+                    "0xe313388c1d1f6e190abc93c30c48698d671da83ca0898646e3573a0c90d892db",
+            });
+        const { events } = res.body as { events: EventType[] };
+        const event = events.find(({ name }) => name === "Auction Successful");
+        if (!event) {
+            throw Error("Event not found");
+        }
+        expect(event?.details?.length).toEqual(4);
+    });
 });

--- a/utils/functions/index.ts
+++ b/utils/functions/index.ts
@@ -1,2 +1,3 @@
 export { slugify } from "./slugify";
 export { TimestampParser } from "./timestamp-parser";
+export { isNullAddress } from "./is-null-address";

--- a/utils/functions/is-null-address.ts
+++ b/utils/functions/is-null-address.ts
@@ -1,0 +1,3 @@
+export const isNullAddress = (address: string): boolean => {
+    return address === "0x0000000000000000000000000000000000000000";
+};


### PR DESCRIPTION
## What?
- The main objective was to add decoders for Hero Auction Contract of DFK.

## How?
Decoders were added for the following events
- Auction Successful
- Auction Cancelled
- Auction Created

## Testing
- Tests were written for the events by providing some mock transaction hashes.